### PR TITLE
Fix: Correctly save menus and navigate to menu list

### DIFF
--- a/koach8/src/pages/MenuBuilder.jsx
+++ b/koach8/src/pages/MenuBuilder.jsx
@@ -191,8 +191,7 @@ export default function MenuBuilder() {
     try {
       const createdMenu = await SavedMenu.create({
         name: menuName,
-        menu_data: JSON.stringify(meals),
-        user_id: user.id,
+        items: JSON.stringify(meals)
       });
 
       if (!createdMenu || !createdMenu.id) {

--- a/koach8/src/pages/index.jsx
+++ b/koach8/src/pages/index.jsx
@@ -105,7 +105,7 @@ function PagesContent() {
                 
                 <Route path="/MenuBuilder" element={<MenuBuilder />} />
                 
-                <Route path="/MyMenus" element={<MyMenus />} />
+                <Route path="/mymenus" element={<MyMenus />} />
                 
                 <Route path="/ViewMenu" element={<ViewMenu />} />
                 


### PR DESCRIPTION
This commit fixes three issues that caused the "Save Menu" feature to fail:

1.  The `user_id` is no longer sent in the payload when creating a menu, as it is already handled by the backend.
2.  The payload key for menu items has been changed from `menu_data` to `items` to match the backend schema.
3.  The route for the "My Menus" page has been changed to `/mymenus` to match the navigation link.